### PR TITLE
Allow ALL_PROJECTS env var to be false

### DIFF
--- a/src/cinder_snapshooter/snapshot_creator.py
+++ b/src/cinder_snapshooter/snapshot_creator.py
@@ -135,7 +135,7 @@ def register_args(parser):
         "--all-projects",
         help="Run on all projects",
         action="store_true",
-        default="ALL_PROJECTS" in os.environ,
+        default=str2bool(os.environ.get("ALL_PROJECTS", "false")),
     )
 
 

--- a/src/cinder_snapshooter/snapshot_destroyer.py
+++ b/src/cinder_snapshooter/snapshot_destroyer.py
@@ -22,6 +22,8 @@ import sys
 
 import structlog
 
+from .utils import str2bool
+
 
 log = structlog.get_logger()
 cmd_help = "Destroys expired snapshots"
@@ -87,7 +89,7 @@ def register_args(parser):
         "--all-projects",
         help="Run on all projects",
         action="store_true",
-        default="ALL_PROJECTS" in os.environ,
+        default=str2bool(os.environ.get("ALL_PROJECTS", "false")),
     )
 
 

--- a/src/cinder_snapshooter/utils.py
+++ b/src/cinder_snapshooter/utils.py
@@ -81,4 +81,4 @@ def setup_logging(args):
 
 def str2bool(value: str) -> bool:
     """Convert a string to a boolean using the content of the string"""
-    return value.lower() in ["true", "yes"]
+    return value.lower() in ["true", "yes", "y", "1"]


### PR DESCRIPTION
This way, if one sets the environment variable "ALL_PROJECTS" to true, then decides it should be false, changing the value is enough.
Otherwise "ALL_PROJECTS" will be assumed to be true, even if set to false.